### PR TITLE
Refactor downloader and update setup scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,48 +1,72 @@
 # YouTube Downloader
 
-A simple Python script to download YouTube videos as MP4 (video) or MP3 (audio-only).
+A simple Python script to download YouTube videos as MP4 (video) or MP3 (audio-only) using `yt-dlp`.
+
+**Key Features:**
+*   Download videos as MP4 or audio as MP3.
+*   Supports downloading entire playlists.
+*   Utilizes parallel downloads for faster playlist processing.
+
+## Prerequisites
+
+**FFmpeg is required** for this script to function correctly, especially for:
+*   Merging video and audio streams downloaded by `yt-dlp`.
+*   Converting audio to MP3 format.
+
+The `init_project.sh` script (for Linux/macOS users) will check if FFmpeg is installed and guide you if it's missing.
+
+**Windows Users:** You will need to install FFmpeg manually and ensure it's added to your system's PATH.
+*   Download FFmpeg from [https://ffmpeg.org/download.html](https://ffmpeg.org/download.html).
+*   Follow instructions for your operating system to add the `bin` directory (containing `ffmpeg.exe`) to your PATH environment variable.
 
 ## Setup
 
-1.  **Create a virtual environment:**
-    Open your terminal or command prompt in the project's root directory and run:
+1.  **Create and activate a Python virtual environment** of your choice (e.g., using `venv`, `conda`, `uv`).
+    Example using `venv`:
     ```bash
-    uv venv .venv
+    python -m venv .venv
+    source .venv/bin/activate  # On Linux/macOS
+    # .venv\Scripts\activate   # On Windows CMD
+    # .venv\Scripts\Activate.ps1 # On Windows PowerShell
     ```
 
-2.  **Activate the virtual environment:**
-    *   On **Linux/macOS**:
+2.  **Install dependencies:**
+
+    *   **For Linux/macOS users:**
+        Run the initialization script. It will check for FFmpeg and install Python packages.
         ```bash
-        source .venv/bin/activate
-        ```
-    *   On **Windows** (Command Prompt):
-        ```bash
-        .venv\Scripts\activate
-        ```
-    *   On **Windows** (PowerShell):
-        ```powershell
-        .venv\Scripts\Activate.ps1
+        chmod +x init_project.sh
+        ./init_project.sh
         ```
 
-3.  **Install dependencies:**
-    Once the virtual environment is activated, install the required packages using:
-    ```bash
-    uv pip install -r requirements.txt
-    ```
-    *(Note: We will generate the `requirements.txt` file in a subsequent step.)*
+    *   **For Windows users:**
+        First, ensure FFmpeg is installed and accessible via your system's PATH (see Prerequisites).
+        Then, install the Python packages:
+        ```bash
+        pip install -r requirements.txt
+        ```
+        (Or, if you use `uv`: `uv pip install -r requirements.txt`)
 
 ## Usage
 
-1.  Make sure your virtual environment is activated.
+1.  Make sure your virtual environment is activated and you have run the setup steps.
 2.  Run the script from the project's root directory:
     ```bash
     python main.py
     ```
-3.  The script will prompt you to enter the YouTube video URL and then ask you to choose the download format ('mp3' or 'mp4').
-4.  The downloaded file will be saved in the same directory where the script is located.
+3.  The script will prompt you to enter the YouTube video or playlist URL and then ask you to choose the download format ('mp3' or 'mp4').
+4.  Downloaded files will be saved in a `downloads` directory within the project folder. For playlists, multiple files will be downloaded.
 
 ## Note on MP3 Files
 
-When you choose the 'mp3' format, the script downloads the best available audio-only stream (often in formats like WebM with Opus audio or M4A with AAC audio). It then renames the downloaded file to have an `.mp3` extension.
+When you choose the 'mp3' format, `yt-dlp` attempts to download the best audio and convert it to MP3. This process relies on **FFmpeg** being installed and accessible to `yt-dlp`.
 
-This means the resulting file is not a "true" MP3 encoded file but rather the original audio stream with its container changed. Most modern audio players can handle these files without any issues. However, if you require a strict MP3 file (e.g., for compatibility with older devices), you would need to use additional tools like FFmpeg to perform a full audio conversion. This script does not include FFmpeg integration.
+If FFmpeg is correctly installed and found by `yt-dlp`, you will get a proper MP3 file.
+If FFmpeg is not found, `yt-dlp` might save the audio in a different format (e.g., m4a, opus) or the download/conversion process for MP3 might fail. Please ensure FFmpeg is installed as per the "Prerequisites" section.
+
+## Contributing
+Contributions are welcome! Please feel free to submit a pull request or open an issue.
+
+## License
+This project is open source and available under the [MIT License](LICENSE).
+(You would typically add a LICENSE file to your project)

--- a/init_project.sh
+++ b/init_project.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+echo "Starting project setup..."
+
+# Check for FFmpeg
+if ! command -v ffmpeg &> /dev/null
+then
+    echo "FFmpeg is required but not found."
+    echo "Please install FFmpeg using your system's package manager."
+    echo "Example commands:"
+    echo "  Debian/Ubuntu: sudo apt-get update && sudo apt-get install -y ffmpeg"
+    echo "  Fedora/CentOS/RHEL: sudo yum install -y ffmpeg  # or sudo dnf install -y ffmpeg"
+    exit 1
+fi
+
+echo "Installing Python dependencies..."
+# Install Python dependencies
+pip install -r requirements.txt
+# Or, if you use uv: uv pip install -r requirements.txt
+
+if [ $? -ne 0 ]; then
+    echo "Error installing Python dependencies. Please check the output above."
+    exit 1
+fi
+
+echo "Project setup completed successfully!"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pytube==15.0.0
+yt-dlp


### PR DESCRIPTION
I've updated main.py to use yt-dlp for downloading YouTube videos, enabling MP3 conversion and playlist support with parallel downloads.

Key changes:
- I replaced pytube with yt-dlp in `main.py` and `requirements.txt`.
- I added `init_project.sh` to streamline your environment setup:
    - It checks for ffmpeg and guides installation.
    - It installs Python dependencies.
- I updated `README.md` to:
    - Reflect the use of yt-dlp and its new features.
    - Document ffmpeg as a crucial system dependency.
    - Provide updated setup and usage instructions, referencing `init_project.sh`.
    - Clarify MP3 conversion process with ffmpeg.

The `install_uv.sh` script, an installer for the 'uv' tool, remains unchanged as it's not project-specific.